### PR TITLE
feat: optimizing third person

### DIFF
--- a/places/2440500124.lua
+++ b/places/2440500124.lua
@@ -3187,13 +3187,9 @@ Library:GiveSignal(RunService.RenderStepped:Connect(function()
     local is_thirdperson_enabled = Library.IsMobile and Toggles.ThirdPerson.Value or (Toggles.ThirdPerson.Value and Options.ThirdPersonKey:GetState())
     if is_thirdperson_enabled then
         camera.CFrame = camera.CFrame * CFrame.new(1.5, -0.5, 6.5)
-
-        for _, part in pairs(character:GetDescendants()) do
-            if part:IsA("BasePart") then
-                part.LocalTransparencyModifier = 0
-            end
-        end
     end
+
+    character:SetAttribute("ShowInFirstPerson", is_thirdperson_enabled)
 
     if mainGameSrc then
         mainGameSrc.fovtarget = Options.FOV.Value


### PR DESCRIPTION
instead of looping through all the descendants of the character every 0,016 seconds it will now set the "ShowInFirstPerson" attribute of the character to true (or false).